### PR TITLE
re-adds attoparsec to deps

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ dependencies:
 - network  # required when using bytestring
 - megaparsec  # may be useful for parsing the input
 - parser-combinators  # contains a helpful count function
+- attoparsec # alternative to megaparsec and parser-combinators
 - text  # use Text rather than String
 - stm  # may help with a concurrent database
 - containers  # may help with the database structure and debugging


### PR DESCRIPTION
I personally find `attoparsec` simpler than `megaparsec` and it has the benefit of not requiring `parser-combinators`.